### PR TITLE
4 team stats methods cont

### DIFF
--- a/data/game_fixture_opponent_testing.csv
+++ b/data/game_fixture_opponent_testing.csv
@@ -1,0 +1,6 @@
+"game_id","season","type","date_time","away_team_id","home_team_id","away_goals","home_goals","outcome","home_rink_side_start","venue","venue_link","venue_time_zone_id","venue_time_zone_offset","venue_time_zone_tz"
+"2012030221","2011012","P",2013-05-11,"17","18",1,4,"away win REG","left","Honda Center","/api/v1/venues/null","America/Los_Angeles",-7,"PDT"
+"2012030222","2011012","P",2013-05-11,"17","18",5,0,"away win REG","left","Honda Center","/api/v1/venues/null","America/Los_Angeles",-7,"PDT"
+"2012030223","2012013","P",2013-05-11,"18","17",4,1,"away win REG","left","Honda Center","/api/v1/venues/null","America/Los_Angeles",-7,"PDT"
+"2012030224","2012013","P",2013-05-11,"10","17",0,2,"away win REG","left","Honda Center","/api/v1/venues/null","America/Los_Angeles",-7,"PDT"
+"2012030225","2012013","P",2013-05-11,"17","10",1,4,"away win REG","left","Honda Center","/api/v1/venues/null","America/Los_Angeles",-7,"PDT"

--- a/data/game_team_stats_fixture_opponent_testing.csv
+++ b/data/game_team_stats_fixture_opponent_testing.csv
@@ -1,0 +1,11 @@
+"game_id","team_id","HoA","won","settled_in","head_coach","goals","shots","hits","pim","powerPlayOpportunities","powerPlayGoals","faceOffWinPercentage","giveaways","takeaways"
+"2012030221","17","away",TRUE,"OT","John Tortorella",2,35,44,8,3,0,44.8,17,7
+"2012030221","18","home",FALSE,"OT","Claude Julien",3,48,51,6,4,1,55.2,4,5
+"2012030222","17","away",TRUE,"REG","John Tortorella",2,37,33,11,5,0,51.7,1,4
+"2012030222","18","home",FALSE,"REG","Claude Julien",5,32,36,19,1,0,48.3,16,6
+"2012030223","17","home",FALSE,"REG","Claude Julien",2,34,28,6,0,0,61.8,10,7
+"2012030223","18","away",TRUE,"REG","John Tortorella",1,24,37,2,2,0,38.2,7,9
+"2012030224","17","home",TRUE,"OT","Claude Julien",3,40,24,8,4,2,53.7,8,6
+"2012030224","10","away",FALSE,"OT","John Tortorella",4,32,40,8,4,1,46.3,9,7
+"2012030225","17","away",FALSE,"REG","John Tortorella",1,29,25,13,2,1,50.9,5,3
+"2012030225","10","home",TRUE,"REG","John Tortorella",1,29,25,13,2,1,50.9,5,3

--- a/lib/team_stats.rb
+++ b/lib/team_stats.rb
@@ -73,7 +73,7 @@ module TeamStats
   def win_percentage_by_season(team_id) #helper
     season_win_percentage = {}
     all_seasons(team_id).each do |year|
-      season_win_percentage[year] = ((win_count_per_year(team_id)[year].to_f/ game_count_per_year(team_id)[year]) * 100)
+      season_win_percentage[year] = ((win_count_per_year(team_id)[year].to_f / game_count_per_year(team_id)[year]) * 100)
     end
     season_win_percentage
   end
@@ -167,41 +167,41 @@ def all_losses_by_team(team_id) #helper
     end
 end
 
-#   def head_to_head(team_id)
-# win percentage vs all teams, hash form
-# opponent_win_percentage = {}
-# all_seasons(team_id).each do |year|
-#   opponent_win_percentage[team_id.team_id_swap(team_id)] = ((all_wins_vs_opponent(team_id)/ all_games_vs_opponent(team_id)) * 100)
-#   module required for team_id_swap?
+def head_to_head(team_id)
+  win_percentage_by_team = {}
+  all_wins_vs_opponent(team_id).each do |team_name, wins|
+    win_percentage_by_team[team_name] = ((wins.to_f / all_games_vs_opponent(team_id)[team_name]).round(2))
+  end
+  win_percentage_by_team
+end
+
+# def win_percentage_by_season(team_id) #helper
+#   season_win_percentage = {}
+#   all_seasons(team_id).each do |year|
+#     season_win_percentage[year] = ((win_count_per_year(team_id)[year].to_f / game_count_per_year(team_id)[year]) * 100)
+#   end
+#   season_win_percentage
 # end
-# season_win_percentage
-#
-#
+
+
+
 
 def all_wins_vs_opponent(team_id) #helper
   win_game_ids(team_id)
-   win_games = @games.repo.find_all do |game| #break into helper
+   @game_ids = @games.repo.find_all do |game| #break into helper
      win_game_ids(team_id).include?(game.game_id)
      end
-      all_teams = []
-      win_games.each do |win|
-        all_teams << win.away_team_id << win.home_team_id
-      end
-      count_by_team_name = {}
-      opponents = all_teams.reject { |team| team == team_id }
-      opponents.each do |team|
-        count_by_team_name[team] = opponents.count(team)
-        binding.pry
-      end
-      count_by_team_name
-  binding.pry
-  #group by then covert id to name and array to count?
-  #repeat for all_games_vs_opponent
+    populate_list
+    count_by_team_name(team_id)
 end
 
 def all_games_vs_opponent(team_id)
+    @game_ids = @games.repo.find_all do |game| #break into helper
+      all_game_ids_by_team(team_id).include?(game.game_id)
+      end
+    populate_list
+    count_by_team_name(team_id)
 end
-
 
 def win_game_ids(team_id)
   all_wins_by_team(team_id).map do |win| #break into a helper
@@ -209,8 +209,21 @@ def win_game_ids(team_id)
   end
 end
 
+def populate_list #helper
+  @all_teams = []
+  @game_ids.each do |game|
+    @all_teams << game.away_team_id << game.home_team_id
+  end
+end
 
-
+def count_by_team_name(team_id) #helper
+  count_by_team_name = {}
+  opponents = @all_teams.reject { |team| team == team_id }
+  opponents.each do |team|
+    count_by_team_name[team_id_swap(team)] = opponents.count(team)
+  end
+  count_by_team_name
+end
 
 
 

--- a/lib/team_stats.rb
+++ b/lib/team_stats.rb
@@ -7,7 +7,8 @@ module TeamStats
       end
       team
     end
-    # team_info should be a hash output with 6 key value pairs
+    # team_info should be a hash output with 6 key value pairs,
+    # currently has 7 including parent.
   end
 
   def all_games_played(team_id) #helper
@@ -105,17 +106,17 @@ module TeamStats
   end
 
   def most_goals_scored(team_id)
-    all_goals = all_games_played(team_id).map do |game|
-      game.goals
-    end
-    all_goals.max
+    all_goals(team_id).max
   end
 
   def fewest_goals_scored(team_id)
-    all_goals = all_games_played(team_id).map do |game|
+    all_goals(team_id).min
+  end
+
+  def all_goals(team_id)
+    all = all_games_played(team_id).map do |game|
       game.goals
     end
-    all_goals.min
   end
 
 #   def favorite_opponent(team_id)
@@ -129,11 +130,9 @@ module TeamStats
 # #GAME_CSV
 #
 def biggest_team_blowout(team_id)
-  win_game_ids = all_wins_by_team(team_id).map do |win|
-    win.game_id
-  end
+  win_game_ids(team_id)
    win_games = @games.repo.find_all do |game|
-     win_game_ids.include?(game.game_id)
+     win_game_ids(team_id).include?(game.game_id)
      end
       win_differential = []
       win_games.each do |win|
@@ -143,7 +142,7 @@ def biggest_team_blowout(team_id)
 end
 
 def worst_loss(team_id)
-  loss_game_ids = all_losses_by_team(team_id).map do |loss|
+  loss_game_ids = all_losses_by_team(team_id).map do |loss| #break into a helper
     loss.game_id
   end
    loss_games = @games.repo.find_all do |game|
@@ -169,14 +168,55 @@ def all_losses_by_team(team_id) #helper
 end
 
 #   def head_to_head(team_id)
-#     may need to take in an additional team_id argument?
-#     find all games between these two teams
-#     find win and loss count verse opponent
-#     return in a hash win/loss vs opponent
-#     ex? {wins: 20, losses: 15}
-#   end
+# win percentage vs all teams, hash form
+# opponent_win_percentage = {}
+# all_seasons(team_id).each do |year|
+#   opponent_win_percentage[team_id.team_id_swap(team_id)] = ((all_wins_vs_opponent(team_id)/ all_games_vs_opponent(team_id)) * 100)
+#   module required for team_id_swap?
+# end
+# season_win_percentage
 #
-#   def seasonal_summary(team_id)
+#
+
+def all_wins_vs_opponent(team_id) #helper
+  win_game_ids(team_id)
+   win_games = @games.repo.find_all do |game| #break into helper
+     win_game_ids(team_id).include?(game.game_id)
+     end
+      all_teams = []
+      win_games.each do |win|
+        all_teams << win.away_team_id << win.home_team_id
+      end
+      count_by_team_name = {}
+      opponents = all_teams.reject { |team| team == team_id }
+      opponents.each do |team|
+        count_by_team_name[team] = opponents.count(team)
+        binding.pry
+      end
+      count_by_team_name
+  binding.pry
+  #group by then covert id to name and array to count?
+  #repeat for all_games_vs_opponent
+end
+
+def all_games_vs_opponent(team_id)
+end
+
+
+def win_game_ids(team_id)
+  all_wins_by_team(team_id).map do |win| #break into a helper
+    win.game_id
+  end
+end
+
+
+
+
+
+
+
+
+# def seasonal_summary(team_id)
 #     may need a lot of total stat by year helpers?
 #
 #

--- a/test/team_stats_test.rb
+++ b/test/team_stats_test.rb
@@ -17,14 +17,33 @@ class TeamStatsTest < Minitest::Test
     assert_instance_of StatTracker, @stat_tracker
   end
 
-  # not working as expected...
+  # not working as expected... may need to remove @parent
+  # example below. Need all but @parent attribute
+  # @abbreviation="NJD",
+  # @franchise_id=23,
+  # @link="/api/v1/teams/1",
+  # @parent=#<TeamRepo:0x007f89b6968808 ...>,
+  # @short_name="New Jersey",
+  # @team_id=1,
+  # @team_name="Devils">,
   # def test_team_info_with_all_attributes_is_shown
   #   #expected = Hash
   #   assert_instance_of Hash, @stat_tracker.team_info(17)
   # end
 
   def test_all_games_played_can_be_gathered #helper
+    # binding.pry
     assert_equal 6, @stat_tracker.all_games_played(17).count
+  end
+
+  def test_all_wins_all_time_can_be_gathered_in_a_list
+    assert_instance_of Array, @stat_tracker.all_wins_by_team(17)
+    assert_equal 2, @stat_tracker.all_wins_by_team(17).count
+  end
+
+  def test_all_losses_all_time_can_be_gathered_in_a_list
+    assert_instance_of Array, @stat_tracker.all_losses_by_team(17)
+    assert_equal 4, @stat_tracker.all_losses_by_team(17).count
   end
 
   def test_all_seasons_played_by_a_team_can_be_added_to_a_list
@@ -33,6 +52,7 @@ class TeamStatsTest < Minitest::Test
 
   def test_teams_best_and_worst_season_based_on_win_percentage_can_be_shown
     #expected = Integer
+    #spec harness now says needs to convert to string "20122013"
     assert_equal 2012, @stat_tracker.best_season(17) #50%
     assert_equal 2011, @stat_tracker.worst_season(17) #0%
   end
@@ -78,13 +98,32 @@ class TeamStatsTest < Minitest::Test
   end
 
   # def test_teams_head_to_head_record_is_shown_versus_a_specific_opponent
+  #   @game_path = './data/game_fixture_opponent_testing.csv'
+  #   @team_path = './data/team_info.csv'
+  #   @game_teams_path = './data/game_team_stats_fixture_opponent_testing.csv'
+  #   @locations = {games: @game_path,
+  #     teams: @team_path,
+  #     game_teams: @game_teams_path}
+  #
+  #   @st = StatTracker.from_csv(@locations)
   #   # expected = Hash
-  #
-  #   assert_equal (team_id => ), @stat_tacker.head_to_head(17, 16) #two arguments
-  #   #head_to_head method not shown with an argument
-  #   #but may be a good idea if we specify by opponent
+  #   assert_equal Hash, @st.head_to_head(17).class
   # end
-  #
+
+#   def test_all_wins_can_be_grouped_by_opponent
+#     @game_path = './data/game_fixture_opponent_testing.csv'
+#     @team_path = './data/team_info.csv'
+#     @game_teams_path = './data/game_team_stats_fixture_opponent_testing.csv'
+#     @locations = {games: @game_path,
+#       teams: @team_path,
+#       game_teams: @game_teams_path}
+#
+#     @st = StatTracker.from_csv(@locations)
+#     # expected = Hash
+# # binding.pry
+#     assert_equal Hash, @st.all_wins_listed_vs_opponent(17)
+#   end
+
   # def test_teams_seasonal_summary_is_shown_for_each_season_it_has_played
   #   # each season, a hash with two keys (:preseason, :regular_season)
   #   # each key points to a hash with following keys => :win_percentage,

--- a/test/team_stats_test.rb
+++ b/test/team_stats_test.rb
@@ -97,32 +97,37 @@ class TeamStatsTest < Minitest::Test
     assert_equal 5, @st.worst_loss(17) #using game_team_stats_fixture.csv
   end
 
-  # def test_teams_head_to_head_record_is_shown_versus_a_specific_opponent
-  #   @game_path = './data/game_fixture_opponent_testing.csv'
-  #   @team_path = './data/team_info.csv'
-  #   @game_teams_path = './data/game_team_stats_fixture_opponent_testing.csv'
-  #   @locations = {games: @game_path,
-  #     teams: @team_path,
-  #     game_teams: @game_teams_path}
-  #
-  #   @st = StatTracker.from_csv(@locations)
-  #   # expected = Hash
-  #   assert_equal Hash, @st.head_to_head(17).class
-  # end
+  def test_teams_head_to_head_record_is_shown_versus_a_specific_opponent
+    @game_path = './data/game_fixture_opponent_testing.csv'
+    @team_path = './data/team_info.csv'
+    @game_teams_path = './data/game_team_stats_fixture_opponent_testing.csv'
+    @locations = {games: @game_path,
+      teams: @team_path,
+      game_teams: @game_teams_path}
 
-#   def test_all_wins_can_be_grouped_by_opponent
-#     @game_path = './data/game_fixture_opponent_testing.csv'
-#     @team_path = './data/team_info.csv'
-#     @game_teams_path = './data/game_team_stats_fixture_opponent_testing.csv'
-#     @locations = {games: @game_path,
-#       teams: @team_path,
-#       game_teams: @game_teams_path}
-#
-#     @st = StatTracker.from_csv(@locations)
-#     # expected = Hash
-# # binding.pry
-#     assert_equal Hash, @st.all_wins_listed_vs_opponent(17)
-#   end
+    @st = StatTracker.from_csv(@locations)
+    expected = ({"Predators"=>0.67, "Maple Leafs"=>0.5})
+
+    assert_equal expected, @st.head_to_head(17)
+  end
+
+  def test_all_wins_and_all_games_can_be_grouped_by_opponent
+    @game_path = './data/game_fixture_opponent_testing.csv'
+    @team_path = './data/team_info.csv'
+    @game_teams_path = './data/game_team_stats_fixture_opponent_testing.csv'
+    @locations = {games: @game_path,
+      teams: @team_path,
+      game_teams: @game_teams_path}
+
+    @st = StatTracker.from_csv(@locations)
+    expected_1 = ({"Predators"=>2, "Maple Leafs"=>1})
+    expected_2 = ({"Predators"=>3, "Maple Leafs"=>2})
+
+    assert_equal expected_1, @st.all_wins_vs_opponent(17)
+    # binding.pry
+    assert_equal expected_2, @st.all_games_vs_opponent(17)
+  end
+
 
   # def test_teams_seasonal_summary_is_shown_for_each_season_it_has_played
   #   # each season, a hash with two keys (:preseason, :regular_season)

--- a/test/team_stats_test.rb
+++ b/test/team_stats_test.rb
@@ -2,14 +2,13 @@ require "./test/test_helper"
 
 class TeamStatsTest < Minitest::Test
 
-  def setup #required different setup, using custom CSV fixture
+  def setup
     @game_path = './data/game_fixture.csv'
     @team_path = './data/team_info.csv'
     @game_teams_path = './data/game_team_stats_fixture_corey.csv'
     @locations = {games: @game_path,
       teams: @team_path,
       game_teams: @game_teams_path}
-
     @stat_tracker = StatTracker.from_csv(@locations)
   end
 
@@ -17,22 +16,19 @@ class TeamStatsTest < Minitest::Test
     assert_instance_of StatTracker, @stat_tracker
   end
 
-  # not working as expected... may need to remove @parent
-  # example below. Need all but @parent attribute
-  # @abbreviation="NJD",
-  # @franchise_id=23,
-  # @link="/api/v1/teams/1",
-  # @parent=#<TeamRepo:0x007f89b6968808 ...>,
-  # @short_name="New Jersey",
-  # @team_id=1,
-  # @team_name="Devils">,
-  # def test_team_info_with_all_attributes_is_shown
-  #   #expected = Hash
-  #   assert_instance_of Hash, @stat_tracker.team_info(17)
-  # end
+  def test_team_info_can_be_shown_in_a_hash_of_six_attributes
+    expected = {
+      "team_id" => 17,
+      "franchise_id" => 12,
+      "short_name" => "Detroit",
+      "team_name" => "Red Wings",
+      "abbreviation" => "DET",
+      "link" => "/api/v1/teams/17"
+    }
+    assert_equal expected, @stat_tracker.team_info(17)
+  end
 
-  def test_all_games_played_can_be_gathered #helper
-    # binding.pry
+  def test_all_games_played_can_be_gathered
     assert_equal 6, @stat_tracker.all_games_played(17).count
   end
 
@@ -51,36 +47,24 @@ class TeamStatsTest < Minitest::Test
   end
 
   def test_teams_best_and_worst_season_based_on_win_percentage_can_be_shown
-    #expected = Integer
+    #original expected = Integer
     #spec harness now says needs to convert to string "20122013"
-    assert_equal 2012, @stat_tracker.best_season(17) #50%
-    assert_equal 2011, @stat_tracker.worst_season(17) #0%
+    assert_equal 2012, @stat_tracker.best_season(17) # => "20122013"
+    assert_equal 2011, @stat_tracker.worst_season(17) # => "20112012"
   end
 
   def test_teams_average_win_percentage_of_all_games_is_shown
-    assert_equal 25.0, @stat_tracker.average_win_percentage(17)
+    assert_equal 0.25, @stat_tracker.average_win_percentage(17)
   end
 
   def test_teams_highest_and_lowest_number_of_goals_in_a_single_game_is_shown
-    # expected = Integ
     assert_equal 4, @stat_tracker.most_goals_scored(17)
     assert_equal 0, @stat_tracker.fewest_goals_scored(17)
   end
 
-  # def test_teams_favorite_opponents_name_is_shown
-  #   expected = String
-  #   assert_equal "Blackhawks", @stat_tracker.favorite_opponent(17)
-  # end
-
-  # def test_teams_rivals_name_is_shown
-  #   expected = String
-  #   assert_equal "Blackhawks", @stat_tracker.rival(17)
-  # end
-
   def test_all_wins_and_losses_for_a_team_can_be_shown
-    # array of 3 game_team objects for each (team happens to be 3-3)
-    assert_equal 2, @stat_tracker.all_wins_by_team(17).count #2
-    assert_equal 4, @stat_tracker.all_losses_by_team(17).count #4
+    assert_equal 2, @stat_tracker.all_wins_by_team(17).count
+    assert_equal 4, @stat_tracker.all_losses_by_team(17).count
   end
 
   def test_teams_biggest_blowout_win__and_worst_loss_by_goal_differential_is_shown
@@ -93,8 +77,8 @@ class TeamStatsTest < Minitest::Test
 
     @st = StatTracker.from_csv(@locations)
 
-    assert_equal 3, @st.biggest_team_blowout(17) #using game_team_stats_fixture.csv
-    assert_equal 5, @st.worst_loss(17) #using game_team_stats_fixture.csv
+    assert_equal 3, @st.biggest_team_blowout(17)
+    assert_equal 5, @st.worst_loss(17)
   end
 
   def test_teams_head_to_head_record_is_shown_versus_a_specific_opponent
@@ -124,10 +108,22 @@ class TeamStatsTest < Minitest::Test
     expected_2 = ({"Predators"=>3, "Maple Leafs"=>2})
 
     assert_equal expected_1, @st.all_wins_vs_opponent(17)
-    # binding.pry
     assert_equal expected_2, @st.all_games_vs_opponent(17)
   end
 
+  def test_rival_and_favorite_opponent_can_be_shown
+    @game_path = './data/game_fixture_opponent_testing.csv'
+    @team_path = './data/team_info.csv'
+    @game_teams_path = './data/game_team_stats_fixture_opponent_testing.csv'
+    @locations = {games: @game_path,
+      teams: @team_path,
+      game_teams: @game_teams_path}
+
+    @st = StatTracker.from_csv(@locations)
+
+    assert_equal "Predators", @st.favorite_opponent(17)
+    assert_equal "Maple Leafs", @st.rival(17)
+  end
 
   # def test_teams_seasonal_summary_is_shown_for_each_season_it_has_played
   #   # each season, a hash with two keys (:preseason, :regular_season)


### PR DESCRIPTION
Team Stats methods are now all built and passing aside from the final method (seasonal_summary).

Currently, all methods take team_id in as an integer, however the spec sheet now asks for this to be a string. Since many of our other classes are affected by this as well - I think we should hold off and address these cross-check wide changes as a group so that all tests will still pass.

Similarly, some outputs are now expected as a string, whereas these tests are passing with integer values. Again, this goes back to how we take in data as a whole with StatTracker.

Additional testing CSV's created and added as well.